### PR TITLE
Change order of reporter methods calls in PerformableScenario

### DIFF
--- a/jbehave-core/src/main/java/org/jbehave/core/embedder/PerformableTree.java
+++ b/jbehave-core/src/main/java/org/jbehave/core/embedder/PerformableTree.java
@@ -945,8 +945,8 @@ public class PerformableTree {
         		return;
         	}
         	context.stepsContext().resetScenario();
-        	context.reporter().beforeScenario(scenario.getTitle());
         	context.reporter().scenarioMeta(scenario.getMeta());
+        	context.reporter().beforeScenario(scenario.getTitle());
             State state = context.state();
 			if (!examplePerformableScenarios.isEmpty()) {
 				context.reporter().beforeExamples(scenario.getSteps(),


### PR DESCRIPTION
Swap calls of reporter.scenarioMeta() and reporter.beforeScenario() in
PerformableScenario.perform method to have access to Meta in further
beforeScenario calls